### PR TITLE
Add type defs.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+import { Registry } from "@ember/controller";
+
+/**
+ * Decorator that wraps `Ember.inject.controller`
+ *
+ * Injects a controller into a Controller as the decorated property
+ *
+ *  ```javascript
+ * import Controller from '@ember/controller';
+ * import { controller } from 'ember-decorators/controller';
+ *
+ * export default class IndexController extends Controller {
+ *   @controller() application;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [controllerName] - The name of the controller to inject. If not provided, the property name will be used
+ */
+export function controller(): PropertyDecorator;
+/**
+ * Decorator that wraps `Ember.inject.controller`
+ *
+ * Injects a controller into a Controller as the decorated property
+ *
+ *  ```javascript
+ * import Controller from '@ember/controller';
+ * import { controller } from 'ember-decorators/controller';
+ *
+ * export default class IndexController extends Controller {
+ *   @controller() application;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [controllerName] - The name of the controller to inject. If not provided, the property name will be used
+ */
+export function controller<K extends keyof Registry>(
+  name: K
+): PropertyDecorator;

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,29 @@ import { Registry } from "@ember/controller";
  * @function
  * @param {String} [controllerName] - The name of the controller to inject. If not provided, the property name will be used
  */
-export function controller(): PropertyDecorator;
+export function service(target: any, key: any): any;
+/**
+ * Decorator that wraps `Ember.inject.controller`
+ *
+ * Injects a controller into a Controller as the decorated property
+ *
+ *  ```javascript
+ * import Controller from '@ember/controller';
+ * import { controller } from 'ember-decorators/controller';
+ *
+ * export default class IndexController extends Controller {
+ *   @controller() application;
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} [controllerName] - The name of the controller to inject. If not provided, the property name will be used
+ */
+export function service(
+  target: any,
+  key: any,
+  descriptor: PropertyDescriptor
+): PropertyDescriptor;
 /**
  * Decorator that wraps `Ember.inject.controller`
  *


### PR DESCRIPTION
As with the Ember Data decorator type defs, I've intentionally duplicated the docs so they show up correctly for both overloads in e.g. VS Code.

This does *not* support calling it as `@controller foo` and I've yet to figure out an invocation that *does* support both that *and* the longer `@controller('foo') fooController`. One option is to only support the callable version from TS's perspective:

```ts
@controller() foo: Foo;
@controller('foo') fooController: Foo;
```

I'm currently inclined slightly that way b/c it seems to me that supporting the second of those forms *is* important.