### PR TITLE
test: add tests for Ember object model

### DIFF
--- a/tests/unit/controller-test.js
+++ b/tests/unit/controller-test.js
@@ -6,7 +6,7 @@ import { controller } from '@ember-decorators/controller';
 
 moduleFor('javascript | @controller', { integration: true });
 
-test('it works', function(assert) {
+test('it works (ES6)', function(assert) {
   const FooController = Controller.extend();
 
   this.register('controller:foo', FooController);
@@ -22,7 +22,23 @@ test('it works', function(assert) {
   assert.ok(bar.get('foo') instanceof FooController, 'controller injected correctly');
 });
 
-test('controller decorator works with controller name', function(assert) {
+test('it works (Ember object model)', function(assert) {
+  const FooController = Controller.extend();
+
+  this.register('controller:foo', FooController);
+
+  const BarController = Controller.extend({
+    @controller foo: null
+  });
+
+  this.register('controller:bar', BarController);
+
+  const bar = this.container.lookup('controller:bar');
+
+  assert.ok(bar.get('foo') instanceof FooController, 'controller injected correctly');
+});
+
+test('controller decorator works with controller name (ES6)', function(assert) {
   const FooController = Controller.extend();
 
   this.register('controller:foo', FooController);
@@ -38,8 +54,23 @@ test('controller decorator works with controller name', function(assert) {
   assert.ok(bar.get('baz') instanceof FooController, 'controller injected correctly');
 });
 
+test('controller decorator works with controller name (Ember object model)', function(assert) {
+  const FooController = Controller.extend();
 
-test('can set controller field', function(assert) {
+  this.register('controller:foo', FooController);
+
+  const BarController = Controller.extend({
+    @controller('foo') baz: null
+  });
+
+  this.register('controller:bar', BarController);
+
+  const bar = this.container.lookup('controller:bar');
+
+  assert.ok(bar.get('baz') instanceof FooController, 'controller injected correctly');
+});
+
+test('can set controller field (ES6)', function(assert) {
   assert.expect(0);
 
   const FooController = Controller.extend();
@@ -49,6 +80,24 @@ test('can set controller field', function(assert) {
   class BarController extends Controller {
     @controller foo
   }
+
+  this.register('controller:bar', BarController);
+
+  const bar = this.container.lookup('controller:bar');
+
+  bar.set('foo', FooController.create());
+});
+
+test('can set controller field (Ember object model)', function(assert) {
+  assert.expect(0);
+
+  const FooController = Controller.extend();
+
+  this.register('controller:foo', FooController);
+
+  const BarController = Controller.extend({
+    @controller foo: null
+  });
 
   this.register('controller:bar', BarController);
 


### PR DESCRIPTION
Tests cannot actually be built, because of some funky TypeScript stuff. For some reason you cannot resue the `baz` identifier.

https://github.com/ember-decorators/ember-decorators/issues/206